### PR TITLE
Support SSL DB, and config-volumes for bundled-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Role Variables
 | `nginx_controller_tsdb_nfs_path` | `""` | Time series database NFS path (only if `tsdb_volume_type` is `nfs`) | No |
 | `nginx_controller_tsdb_nfs_host` | `""` | Time series database NFS host (only if `tsdb_volume_type` is `nfs`) | No |
 | `nginx_controller_tsdb_aws_volume_id` | `""` | Time series database AWS EBS Volume ID (only if `tsdb_volume_type` is `aws`) | No |
+| `nginx_controller_configdb_volume_type` | `""` | Backing volume for config database. (local, nfs or aws) | No |
+| `nginx_controller_configdb_nfs_path` | `""` | Config database NFS path (only if `configdb_volume_type` is `nfs`) | No |
+| `nginx_controller_configdb_nfs_host` | `""` | Config database NFS host (only if `configdb_volume_type` is `nfs`) | No |
+| `nginx_controller_configdb_aws_volume_id` | `""` | Config database AWS EBS Volume ID (only if `configdb_volume_type` is `aws`) | No |
 | `nginx_controller_smtp_host` | `""` | SMTP Host for emails. | Yes |
 | `nginx_controller_smtp_port` | `"25"` | SMTP Port for emails. | No |
 | `nginx_controller_smtp_authentication` | `""` | Specify if SMTP needs auth (true or false). | Yes |
@@ -57,6 +61,9 @@ Role Variables
 | `nginx_controller_overwrite_existing_configs` | `false` | Specify if the existing config for controller should be overwritten (true or false). | No |
 | `nginx_controller_auto_install_docker` | `false` | Specify if docker needs to be installed as part of the installation process (true or false). | No |
 | `nginx_controller_bundled_db` | `false` | Specify if the installation process should use a bundled database (version >=3.8). | No |
+
+> _Note_ `nginx_controller_configdb_*` options are for use with the `nginx_controller_bundled_db`,
+>  and are mutually exclusive with the `nginx_controller_db_` parameters.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,11 @@
 # defaults file for ansible-controller
 
 # empty strings are defined to allow ternary evaluation when these optional parameters are not provided.
+nginx_controller_configdb_volume_type: ""
+nginx_controller_configdb_nfs_path: ""
+nginx_controller_configdb_nfs_host: ""
+nginx_controller_configdb_aws_volume_id: ""
+nginx_controller_tsdb_volume_type: ""
 nginx_controller_tsdb_nfs_path: ""
 nginx_controller_tsdb_nfs_host: ""
 nginx_controller_tsdb_aws_volume_id: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,14 @@
     - nginx_controller_admin_email
     - nginx_controller_admin_password
 
+- name: Check for conflicting DB options
+  fail:
+    msg: "You must chose either the bundled_db or provide db connection details. The `nginx_controller_bundled_db` and optional `nginx_controller_configdb_volume_*` variables are mutually exclusive with `nginx_controller_db_*` options"
+  when:
+    - ( ( nginx_controller_bundled_db | bool ) and nginx_controller_db_host != "" ) or
+      ( ( not nginx_controller_bundled_db ) and nginx_controller_db_host == "" ) or
+      ( ( not nginx_controller_bundled_db ) and nginx_controller_configdb_volume_type != "" )
+
 - name: "Controller - Extracting"
   unarchive:
     src: "{{ nginx_controller_tarball }}"
@@ -49,21 +57,25 @@
       --admin-lastname '{{ nginx_controller_admin_lastname }}' \
       --admin-email '{{ nginx_controller_admin_email }}' \
       --admin-password '{{ nginx_controller_admin_password }}' \
-      {{ (nginx_controller_tsdb_volume_type == "nfs") | ternary('--tsdb-nfs-path ' + nginx_controller_tsdb_nfs_path,'') }} \
-      {{ (nginx_controller_tsdb_volume_type == "nfs") | ternary('--tsdb-nfs-host ' + nginx_controller_tsdb_nfs_host,'') }} \
-      {{ (nginx_controller_tsdb_volume_type == "aws") | ternary('--tsdb-aws-volume-id ' + nginx_controller_tsdb_aws_volume_id,'') }} \
-      {{ ((nginx_controller_apigw_cert is defined and nginx_controller_apigw_cert | length > 0) and (nginx_controller_apigw_key is defined and nginx_controller_apigw_key | length > 0) ) | ternary('--apigw-cert ' + nginx_controller_apigw_cert,'') }} \
-      {{ ((nginx_controller_apigw_cert is defined and nginx_controller_apigw_cert | length > 0) and (nginx_controller_apigw_key is defined and nginx_controller_apigw_key | length > 0) ) | ternary('--apigw-key ' + nginx_controller_apigw_key,'') }} \
-      {{ (nginx_controller_smtp_authentication | bool) | ternary('--smtp-user ' + nginx_controller_smtp_user,'') }} \
-      {{ (nginx_controller_smtp_authentication | bool) | ternary('--smtp-password ' + nginx_controller_smtp_password,'') }} \
+      {{ (nginx_controller_tsdb_volume_type == "nfs") | ternary("--tsdb-nfs-path '" + nginx_controller_tsdb_nfs_path + "'",'') }} \
+      {{ (nginx_controller_tsdb_volume_type == "nfs") | ternary("--tsdb-nfs-host '" + nginx_controller_tsdb_nfs_host + "'",'') }} \
+      {{ (nginx_controller_tsdb_volume_type == "aws") | ternary("--tsdb-aws-volume-id '" + nginx_controller_tsdb_aws_volume_id + "'",'') }} \
+      {{ (nginx_controller_configdb_volume_type != "" ) | ternary("--configdb-volume-type '" + nginx_controller_configdb_volume_type + "'", '') }} \
+      {{ (nginx_controller_configdb_volume_type == "nfs") | ternary("--configdb-nfs-path '" + nginx_controller_configdb_nfs_path + "'",'') }} \
+      {{ (nginx_controller_configdb_volume_type == "nfs") | ternary("--configdb-nfs-host '" + nginx_controller_configdb_nfs_host + "'",'') }} \
+      {{ (nginx_controller_configdb_volume_type == "aws") | ternary("--configdb-aws-volume-id '" + nginx_controller_configdb_aws_volume_id + "'",'') }} \
+      {{ ((nginx_controller_apigw_cert is defined and nginx_controller_apigw_cert | length > 0) and (nginx_controller_apigw_key is defined and nginx_controller_apigw_key | length > 0) ) | ternary("--apigw-cert '" + nginx_controller_apigw_cert + "'",'') }} \
+      {{ ((nginx_controller_apigw_cert is defined and nginx_controller_apigw_cert | length > 0) and (nginx_controller_apigw_key is defined and nginx_controller_apigw_key | length > 0) ) | ternary("--apigw-key '" + nginx_controller_apigw_key + "'",'') }} \
+      {{ (nginx_controller_smtp_authentication | bool) | ternary("--smtp-user '" + nginx_controller_smtp_user + "'",'') }} \
+      {{ (nginx_controller_smtp_authentication | bool) | ternary("--smtp-password '" + nginx_controller_smtp_password + "'",'') }} \
       {{ (nginx_controller_self_signed_cert | bool) | ternary('--self-signed-cert','') }} \
       {{ (nginx_controller_overwrite_existing_configs | bool) | ternary('--overwrite-existing-configs','') }} \
       {{ (nginx_controller_auto_install_docker | bool) | ternary('--auto-install-docker','') }} \
-      {{ ((nginx_controller_bundled_db | bool) and ( nginx_controller_version is version('3.8', operator='ge', strict=True ))) | ternary('--use-bundled-db','--database-host "' + nginx_controller_db_host + '" --database-port "' + nginx_controller_db_port + '" --database-user "' + nginx_controller_db_user + '" --database-password "' + nginx_controller_db_password + '"' ) }} \
-      {{ (nginx_controller_db_enable_ssl | bool) | ternary('--db-enable-ssl','') }} \
-      {{ ((nginx_controller_db_enable_ssl | bool) and (nginx_controller_db_client_cert | length > 0)) | ternary('--db-client-cert ' + nginx_controller_db_client_cert,'') }} \
-      {{ ((nginx_controller_db_enable_ssl | bool) and (nginx_controller_db_client_key | length > 0)) | ternary('--db-client-key ' + nginx_controller_db_client_key,'') }} \
-      {{ ((nginx_controller_db_enable_ssl | bool) and (nginx_controller_db_ca | length > 0)) | ternary('--db-ca ' + nginx_controller_db_ca,'') }} \
+      {{ ((nginx_controller_bundled_db | bool) and ( nginx_controller_version is version('3.8', operator='ge', strict=True ))) | ternary("--use-bundled-db","--database-host '" + nginx_controller_db_host + "' --database-port '" + nginx_controller_db_port + "' --database-user '" + nginx_controller_db_user + "' --database-password '" + nginx_controller_db_password + "'" ) }} \
+      {{ ((nginx_controller_db_enable_ssl | bool) and ( not nginx_controller_bundled_db )) | ternary('--db-enable-ssl true','') }} \
+      {{ ((nginx_controller_db_enable_ssl | bool) and (nginx_controller_db_client_cert | length > 0)) | ternary("--db-client-cert '" + nginx_controller_db_client_cert + "'",'') }} \
+      {{ ((nginx_controller_db_enable_ssl | bool) and (nginx_controller_db_client_key | length > 0)) | ternary("--db-client-key '" + nginx_controller_db_client_key + "'",'') }} \
+      {{ ((nginx_controller_db_enable_ssl | bool) and (nginx_controller_db_ca | length > 0)) | ternary("--db-ca '" + nginx_controller_db_ca + "'",'') }} \
       {{ ((nginx_controller_version is version('3.5', operator='ge', strict=True)  ) ) | ternary('--non-interactive','') }}
   args:
     chdir: "{{ nginx_controller_install_path }}/controller-installer"


### PR DESCRIPTION
I did some more testing with remote and bundled databases. 

This PR adds the following:

* Support for configdb-volume-* parameters, so the pg_data can be stored on NFS/AWS shares.
* It also fixes support for using SSL authentication with remote databases.
* wraps variables in single-quotes to prevent any shell interpolation.
* Some basic validation that user isn't combining bundled-db and remote-db parameters.
